### PR TITLE
use sinon.assert.calledWith in code example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -939,7 +939,7 @@ jQuery.ajax.verify();</code></pre>
         myLib.getCommentsFor("/some/article", callback);
         this.server.respond();
 
-        assert(callback.calledWith([{ id: 12, comment: "Hey there" }]));
+        sinon.assert.calledWith(callback, [{ id: 12, comment: "Hey there" }]));
     }
 }</code></pre>
       <dl>


### PR DESCRIPTION
i guess this code example assumes you have some other library implement a global assert function - this way it uses sinon.assert.calledWith() which in my case was what was available
