### PR TITLE
Matcher documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -230,6 +230,18 @@
         <dd>
           Returns <code>true</code> if spy was always called with the exact provided arguments.
         </dd>
+        <dt><code>spy.calledWithMatch(arg1, arg2, ...);</code></dt>
+        <dd>
+          Returns <code>true</code> if spy was called with matching arguments
+          (and possibly others). This behaves the same as
+          <code>spy.calledWith(sinon.match(arg1), sinon.match(arg2), ...)</code>.
+        </dd>
+        <dt><code>spy.alwaysCalledWithMatch(arg1, arg2, ...);</code></dt>
+        <dd>
+          Returns <code>true</code> if spy was always called with matching arguments
+          (and possibly others). This behaves the same as
+          <code>spy.alwaysCalledWith(sinon.match(arg1), sinon.match(arg2), ...)</code>.
+        </dd>
         <dt><code>spy.calledWithNew();</code></dt>
         <dd>
           Returns <code>true</code> if spy/stub was called the <code>new</code>
@@ -247,6 +259,18 @@
         <dd>
           Returns <code>true</code> if the spy/stub was never called with
           the provided arguments.
+        </dd>
+        <dt><code>spy.notCalledWithMatch(arg1, arg2, ...);</code></dt>
+        <dd>
+          Returns <code>true</code> if the spy/stub was called at least once
+          with arguments not matching the provided ones. This behaves the same as
+          <code>spy.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)</code>.
+        </dd>
+        <dt><code>spy.neverCalledWithMatch(arg1, arg2, ...);</code></dt>
+        <dd>
+          Returns <code>true</code> if the spy/stub was never called with
+          matching arguments. This behaves the same as
+          <code>spy.neverCalledWith(sinon.match(arg1), sinon.match(arg2), ...)</code>.
         </dd>
         <dt><code>spy.threw();</code></dt>
         <dd>Returns <code>true</code> if spy threw an exception at least once.</dd>
@@ -344,6 +368,12 @@ assertEquals("/stuffs", spyCall.args[0]);</code></pre>
         <dd>Returns <code>true</code> if call received provided arguments (and possibly others).</dd>
         <dt><code>spyCall.calledWithExactly(arg1, arg2, ...);</code></dt>
         <dd>Returns <code>true</code> if call received provided arguments and no others.</dd>
+        <dt><code>spyCall.calledWithMatch(arg1, arg2, ...);</code></dt>
+        <dd>Returns <code>true</code> if call received matching arguments (and possibly others). This behaves the same as <code>spyCall.calledWith(sinon.match(arg1), sinon.match(arg2), ...)</code>.</dd>
+        <dt><code>spyCall.notCalledWith(arg1, arg2, ...);</code></dt>
+        <dd>Returns <code>true</code> if call did not receive provided arguments.</dd>
+        <dt><code>spyCall.notCalledWithMatch(arg1, arg2, ...);</code></dt>
+        <dd>Returns <code>true</code> if call did not receive matching arguments. This behaves the same as <code>spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)</code>.</dd>
         <dt><code>spyCall.threw();</code></dt>
         <dd>Returns <code>true</code> if call threw an exception.</dd>
         <dt><code>spyCall.threw("TypeError");</code></dt>
@@ -1149,6 +1179,21 @@ jQuery.ajax.verify();</code></pre>
           Passes if the spy was always called with the provided arguments and no
           others.
         </dd>
+        <dt><code>sinon.assert.calledWithMatch(spy, arg1, arg2, ...)</code></dt>
+        <dd>
+          Passes if the spy was called with matching arguments. This behaves
+          the same as <code>sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...)</code>.
+        </dd>
+        <dt><code>sinon.assert.alwaysCalledWithMatch(spy, arg1, arg2, ...)</code></dt>
+        <dd>
+          Passes if the spy was always called with matching arguments. This behaves
+          the same as <code>sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...)</code>.
+        </dd>
+        <dt><code>sinon.assert.neverCalledWithMatch(spy, arg1, arg2, ...)</code></dt>
+        <dd>
+          Passes if the spy was never called with matching arguments. This behaves
+          the same as <code>sinon.assert.neverCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...)</code>.
+        </dd>
         <dt><code>sinon.assert.threw(spy, exception)</code></dt>
         <dd>
           Passes if the spy threw the given exception. The exception can be a
@@ -1189,7 +1234,7 @@ jQuery.ajax.verify();</code></pre>
       <ul class="nav">
         <li><a href="#sinon-match-api">Matcher API</a></li>
         <li><a href="#sinon-match-andor">Combining matchers</a></li>
-        <li><a href="#sinon-match">Custom matchers</a></li>
+        <li><a href="#sinon-match-custom">Custom matchers</a></li>
       </ul>
       <p>
         Matchers can be passed as arguments to <code>spy.calledWith</code>,
@@ -1204,9 +1249,10 @@ jQuery.ajax.verify();</code></pre>
         author: "cjno"
     };
     var spy = sinon.spy();
+
     spy(book);
 
-    sinon.assert.calledWith(spy, sinon.match.like({ author: "cjno" }));
+    sinon.assert.calledWith(spy, sinon.match({ author: "cjno" }));
     sinon.assert.calledWith(spy, sinon.match.has("pages", 42));
 }</code></pre>
       <pre class="sh_javascript"><code>"test should stub method differently based on argument types": function () {
@@ -1219,8 +1265,40 @@ jQuery.ajax.verify();</code></pre>
 }</code></pre>
       <h3 id="sinon-match-api">Matchers API</h3>
       <dl>
+        <dt><code>sinon.match(number)</code></dt>
+        <dd>Requires the value to be == to the given number.</dd>
+        <dt><code>sinon.match(string)</code></dt>
+        <dd>Requires the value to be a string and have the expectation as a substring.</dd>
+        <dt><code>sinon.match(regexp)</code></dt>
+        <dd>Requires the value to be a string and match the given regular expression.</dd>
+        <dt><code>sinon.match(object)</code></dt>
+        <dd>Requires the value to be not null or undefined and have at least the same properties as <code>expectation</code>. This supports nested matchers.</dd>
+        <dt><code>sinon.match(function)</code></dt>
+        <dd>See <a href="#sinon-match-custom">custom matchers</a>.</dd>
         <dt><code>sinon.match.any</code></dt>
         <dd>Matches anything.</dd>
+        <dt><code>sinon.match.defined</code></dt>
+        <dd>Requires the value to be defined.</dd>
+        <dt><code>sinon.match.truthy</code></dt>
+        <dd>Requires the value to be truthy.</dd>
+        <dt><code>sinon.match.falsy</code></dt>
+        <dd>Requires the value to be falsy.</dd>
+        <dt><code>sinon.match.bool</code></dt>
+        <dd>Requires the value to be a boolean.</dd>
+        <dt><code>sinon.match.number</code></dt>
+        <dd>Requires the value to be a number.</dd>
+        <dt><code>sinon.match.string</code></dt>
+        <dd>Requires the value to be a string.</dd>
+        <dt><code>sinon.match.object</code></dt>
+        <dd>Requires the value to be an object.</dd>
+        <dt><code>sinon.match.func</code></dt>
+        <dd>Requires the value to be a function.</dd>
+        <dt><code>sinon.match.array</code></dt>
+        <dd>Requires the value to be an array.</dd>
+        <dt><code>sinon.match.regexp</code></dt>
+        <dd>Requires the value to be a regular expression.</dd>
+        <dt><code>sinon.match.date</code></dt>
+        <dd>Requires the value to be a date object.</dd>
         <dt><code>sinon.match.same(ref)</code></dt>
         <dd>Requires the value to strictly equal <code>ref</code>.</dd>
         <dt><code>sinon.match.typeOf(type)</code></dt>
@@ -1238,34 +1316,10 @@ jQuery.ajax.verify();</code></pre>
         </dd>
         <dt><code>sinon.match.instanceOf(type)</code></dt>
         <dd>Requires the value to be an instance of the given type.</dd>
-        <dt><code>sinon.match.like(boolean)</code></dt>
-        <dd>Requires the value to be true(ish) or false(ish).</dd>
-        <dt><code>sinon.match.like(string)</code></dt>
-        <dd>Requires the value to be a string and have the expectation as a substring.</dd>
-        <dt><code>sinon.match.like(regexp)</code></dt>
-        <dd>Requires the value to be a string and match the given regular expression.</dd>
-        <dt><code>sinon.match.like(object)</code></dt>
-        <dd>Requires the value to be not null or undefined and have at least the same properties as <code>expectation</code>. This supports nested matchers.</dd>
         <dt><code>sinon.match.has(property[, expectation])</code></dt>
         <dd>Requires the value to define the given property. The property might be inherited via the prototype chain. If the optional expectation is given, the value of the property is deeply compared with the expectation. The expectation can be another matcher.</dd>
         <dt><code>sinon.match.hasOwn(property[, expectation])</code></dt>
         <dd>Same as <code>sinon.match.has</code> but the property must be defined by the value itself. Inherited properties are ignored.</dd>
-        <dt><code>sinon.match.bool</code></dt>
-        <dd>Requires the value to be a boolean.</dd>
-        <dt><code>sinon.match.number</code></dt>
-        <dd>Requires the value to be a number.</dd>
-        <dt><code>sinon.match.string</code></dt>
-        <dd>Requires the value to be a string.</dd>
-        <dt><code>sinon.match.object</code></dt>
-        <dd>Requires the value to be an object.</dd>
-        <dt><code>sinon.match.func</code></dt>
-        <dd>Requires the value to be a function.</dd>
-        <dt><code>sinon.match.array</code></dt>
-        <dd>Requires the value to be an array.</dd>
-        <dt><code>sinon.match.regexp</code></dt>
-        <dd>Requires the value to be a regular expression.</dd>
-        <dt><code>sinon.match.date</code></dt>
-        <dd>Requires the value to be a date object.</dd>
       </dl>
       <h3 id="sinon-match-andor">Combining matchers</h3>
       <p>
@@ -1277,10 +1331,10 @@ jQuery.ajax.verify();</code></pre>
       <pre class="sh_javascript"><code>var stringOrNumber = sinon.match.string.or(sinon.match.number);
 
 var bookWithPages = sinon.match.instanceOf(Book).and(sinon.match.has("pages"));</code></pre>
-      <h3 id="sinon-match">Custom matchers</h3>
+      <h3 id="sinon-match-custom">Custom matchers</h3>
       <p>
         Custom matchers are created with the <code>sinon.match</code> factory
-        which takes a test function and a message. The test function takes a
+        which takes a test function and an optional message. The test function takes a
         value as the only argument, returns <code>true</code> if the
         value matches the expectation and <code>false</code> otherwise.
         The message string is used to generate the error message in case the

--- a/index.html
+++ b/index.html
@@ -25,14 +25,15 @@
     <div class="examples" id="examples">
       <h2>What does Sinon.JS look like?</h2>
       <ul class="nav">
-        <li class="active"><a href="#spy_example">Test spies</a></li>
-        <li><a href="#stub_example">Test stubs</a></li>
+        <li class="active"><a href="#spy_example">Spies</a></li>
+        <li><a href="#stub_example">Stubs</a></li>
         <li><a href="#mock_example">Mocks</a></li>
         <li><a href="#timers_example">Fake timers</a></li>
         <li><a href="#xhr_example">Fake XHR</a></li>
         <li><a href="#server_example">Fake server</a></li>
         <li><a href="#sandbox_example">Sandboxing</a></li>
         <li><a href="#assertion_example">Assertions</a></li>
+        <li><a href="#matcher_example">Matchers</a></li>
       </ul>
       <div id="spy_example">
         <pre class="sh_javascript"><code>"test should call subscriber": function () {
@@ -191,6 +192,22 @@
 }</code></pre>
         <p><a href="docs/#assertions">Assertions documentation</a></p>
       </div>
+      <div id="matcher_example">
+        <pre class="sh_javascript"><code>"test should call subscriber": function () {
+    var spy = sinon.spy();
+
+    PubSub.subscribe("message", spy);
+    PubSub.publishSync("message", undefined);
+
+    assertTrue(spy.calledWith("message", sinon.match.func));
+    assertTrue(spy.calledWithMatch(/[a-z]+/));
+  }</code></pre>
+        <p>
+          <a href="docs/#matchers">Matcher documentation</a>.
+          Example is a modified test from Morgan Roderick's
+          <a href="https://github.com/mroderick/PubSubJS/">PubSubJS</a>.
+        </p>
+      </div>
     </div>
     <div class="docs-intro">
       <h2>Documentation</h2>
@@ -239,8 +256,8 @@
           <li class="ie"><span>Internet Explorer</span> 6.0+</li>
           <li class="ff"><span>Firefox</span> 2.0+</li>
           <li class="chrome"><span>Chrome</span> 7.0+</li>
-          <li class="opera"><span>Opera</span> 10.10+</</li>
-                                                        <li class="safari"><span>Safari</span> 3.2+</li>
+          <li class="opera"><span>Opera</span> 10.10+</li>
+          <li class="safari"><span>Safari</span> 3.2+</li>
           <li class="mobile-safari"><span>Mobile Safari</span> 3.2+</li>
           <li class="android-browser"><span>Android browser</span> 2.1+</li>
           <li class="node-js"><span>Node.js</span> 0.2.x+</li>


### PR DESCRIPTION
Finished the matcher documentation according to the latest changes.
I've put an example for the front page together by modifying the spy example.
Since there was not enough space to keep the navigation on one line I changed "Test spies" and "Test stubs" to Spies" and "Stubs". I hope this is fine with you.
